### PR TITLE
cli option to ci

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ You can configurate `alohomora` from several places:
 
 - **AWS Profile** (`--aws-profile`): Following https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html
 
-- **CLI flag** (`--cli`): Removes colors to avoid odd input. `default: false`
+- **CI flag** (`--ci`): Removes colors to avoid odd input. `default: false`
 
 If you are using `alo` as a [global command](#installation), you can provide all the above options via command line:
 

--- a/src/__tests__/getParameters.spec.ts
+++ b/src/__tests__/getParameters.spec.ts
@@ -51,7 +51,7 @@ describe('getParameters', () => {
 
     SSM.__setResponseForMethods({ getParameter: handler });
 
-    const response = await getParameter({ name: 'Vault_713', environment: 'production', prefix, cli: true });
+    const response = await getParameter({ name: 'Vault_713', environment: 'production', prefix, ci: true });
     expect(stopAndPersist).toHaveBeenCalledTimes(1);
     expect(response).toMatchSnapshot();
   });

--- a/src/__tests__/listParameters.spec.ts
+++ b/src/__tests__/listParameters.spec.ts
@@ -25,7 +25,7 @@ describe('listParameters', () => {
 
     SSM.__setResponseForMethods({ describeParameters: handler });
 
-    const response = await listParameters({ prefix, cli: true });
+    const response = await listParameters({ prefix, ci: true });
     expect(response).toMatchSnapshot();
 
   });
@@ -37,7 +37,7 @@ describe('listParameters', () => {
 
     SSM.__setResponseForMethods({ describeParameters: handler });
 
-    const response = await listParameters({ prefix, environment: 'production', cli: true });
+    const response = await listParameters({ prefix, environment: 'production', ci: true });
     expect(response).toMatchSnapshot();
   });
   it('gets parameters, using nextToken', async () => {
@@ -49,7 +49,7 @@ describe('listParameters', () => {
 
     SSM.__setResponseForMethods({ describeParameters: handler });
 
-    const response = await listParameters({ prefix, cli: true });
+    const response = await listParameters({ prefix, ci: true });
     expect(response).toMatchSnapshot();
     expect(handler).toHaveBeenCalledTimes(2);
   });

--- a/src/__tests__/setParameters.spec.ts
+++ b/src/__tests__/setParameters.spec.ts
@@ -45,7 +45,7 @@ describe('setParameters', () => {
 
     SSM.__setResponseForMethods({ putParameter: handler });
 
-    const response = await setParameter({ name: 'Vault_713', value: 'Boggart', environment: 'production', prefix, cli: true });
+    const response = await setParameter({ name: 'Vault_713', value: 'Boggart', environment: 'production', prefix, ci: true });
     expect(response).toMatchSnapshot();
   });
 

--- a/src/actions/deleteParameter.ts
+++ b/src/actions/deleteParameter.ts
@@ -2,13 +2,13 @@ import SSM from 'aws-sdk/clients/ssm';
 import { AWSError } from 'aws-sdk/lib/core';
 import ora from 'ora';
 
-import { Options } from '../types';
+import { Actions } from '../types';
 import { REGION, API_VERSION, Environment, SUCCESS_SYMBOL } from '../utils/constants';
 import { getGlobalOptions, Command } from '../utils/getGlobalOptions';
 import { setAWSCredentials } from '../utils/setAWSCredentials';
 
 
-interface Input extends Options {
+interface Input extends Actions {
   name: string;
 
 };

--- a/src/actions/exportAsTemplate.ts
+++ b/src/actions/exportAsTemplate.ts
@@ -1,13 +1,13 @@
 import SSM from 'aws-sdk/clients/ssm';
 import groupBy from 'lodash.groupby';
 
-import { Options } from '../types';
+import { Actions } from '../types';
 import { REGION, API_VERSION, MAX_RESULTS_FOR_PATH, Environment, Template } from '../utils/constants';
 import { normalizeSecretKey } from '../utils/normalizeSecretKey';
 import { isValidTemplate } from '../utils/guards';
 import { getGlobalOptions, Command } from '../utils/getGlobalOptions';
 import { setAWSCredentials } from '../utils/setAWSCredentials';
-interface Input extends Options { templateName?: Template, custom?: string };
+interface Input extends Actions { templateName?: Template, custom?: string };
 
 const getParametersByPath = async (params: SSM.GetParametersByPathRequest, region: string): Promise<SSM.ParameterList> => {
 

--- a/src/actions/getParameter.ts
+++ b/src/actions/getParameter.ts
@@ -4,17 +4,17 @@ import dateFormat from 'dateformat'
 import Table from 'cli-table3';
 import ora from 'ora';
 
-import { Options } from '../types';
+import { Actions } from '../types';
 import { REGION, API_VERSION, Environment, DATE_FORMAT, SUCCESS_SYMBOL, DISABLE_TABLE_COLORS } from '../utils/constants';
 import { getGlobalOptions, Command } from '../utils/getGlobalOptions';
 import { setAWSCredentials } from '../utils/setAWSCredentials';
 
 
-interface Input extends Options {
+interface Input extends Actions {
   name: string
 };
 
-export const getParameter = async ({ name, prefix, region = REGION, cli = false, environment = Environment.all }: Input): Promise<string> => {
+export const getParameter = async ({ name, prefix, region = REGION, ci = false, environment = Environment.all }: Input): Promise<string> => {
 
   const loader = ora(`retrieving key ${name} with the prefix /${prefix}  (${region})`).start();
 
@@ -26,7 +26,7 @@ export const getParameter = async ({ name, prefix, region = REGION, cli = false,
 
   const table = new Table({
     head: ['Name', 'Value', 'Environment', 'Updated by', 'Version'],
-    style: cli ? DISABLE_TABLE_COLORS : undefined
+    style: ci ? DISABLE_TABLE_COLORS : undefined
   });
 
 

--- a/src/actions/listParameters.ts
+++ b/src/actions/listParameters.ts
@@ -3,7 +3,7 @@ import dateFormat from 'dateformat';
 import ora from 'ora';
 import SSM from 'aws-sdk/clients/ssm';
 
-import { Options } from '../types';
+import { Actions } from '../types';
 import { API_VERSION, REGION, DATE_FORMAT, SUCCESS_SYMBOL, MAX_RESULTS_FOR_DESCRIBE, DISABLE_TABLE_COLORS } from '../utils/constants';
 import { normalizeSecretKey } from '../utils/normalizeSecretKey';
 import { Command, getGlobalOptions } from '../utils/getGlobalOptions';
@@ -25,13 +25,13 @@ const describeParameters = async (params: SSM.DescribeParametersRequest, region:
   }
 }
 
-export const listParameters = async ({ environment, prefix, region = REGION, cli = false }: Options): Promise<string> => {
+export const listParameters = async ({ environment, prefix, region = REGION, ci = false }: Actions): Promise<string> => {
 
   const loader = ora(`Finding keys with the prefix /${prefix}  (${region})`).start();
 
   const table = new Table({
     head: ['Name', 'Environment', 'Updated by', 'Updated at'],
-    style: cli ? DISABLE_TABLE_COLORS : undefined
+    style: ci ? DISABLE_TABLE_COLORS : undefined
   });
 
   const path = environment ? `/${prefix}/${environment}/` : `/${prefix}`;

--- a/src/actions/setParameter.ts
+++ b/src/actions/setParameter.ts
@@ -3,20 +3,20 @@ import dateFormat from 'dateformat'
 import Table from 'cli-table3';
 import ora from 'ora';
 
-import { Options } from '../types';
+import { Actions } from '../types';
 import { REGION, API_VERSION, Environment, DATE_FORMAT, SUCCESS_SYMBOL, DISABLE_TABLE_COLORS } from '../utils/constants';
 import { getGlobalOptions, Command } from '../utils/getGlobalOptions';
 import { setAWSCredentials } from '../utils/setAWSCredentials';
 
 
-interface Input extends Options {
+interface Input extends Actions {
   name: string;
   value: string;
 
   description?: string;
 };
 
-export const setParameter = async ({ name, value, description, prefix, region = REGION, cli = false, environment = Environment.all }: Input): Promise<string> => {
+export const setParameter = async ({ name, value, description, prefix, region = REGION, ci = false, environment = Environment.all }: Input): Promise<string> => {
 
   const loader = ora(`storing key ${name} with the prefix /${prefix}  (${region})`).start();
 
@@ -35,7 +35,7 @@ export const setParameter = async ({ name, value, description, prefix, region = 
 
   const table = new Table({
     head: ['Name', 'Value', 'Environment', 'Updated at', 'Version'],
-    style: cli ? DISABLE_TABLE_COLORS : undefined
+    style: ci ? DISABLE_TABLE_COLORS : undefined
   });
 
   let response: SSM.PutParameterResult | undefined;

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -16,7 +16,7 @@ program
   .option('--aws-secret-access-key [AWS_SECRET_ACCESS_KEY]', 'Following https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html', undefined)
   .option('--aws-session-token [AWS_SESSION_TOKEN]', 'Following https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html', undefined)
   .option('--aws-profile [AWS_PROFILE]', 'Following https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html', undefined)
-  .option('--cli', 'Removes colors to avoid odd input', false)
+  .option('--ci', 'Removes colors to avoid odd input', false)
 
 program
   .command('list')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
 
 import { Environment } from './utils/constants';
 
-export interface Options { environment?: Environment | string, prefix: string, region?: string, cli?: boolean };
+export interface Actions { environment?: Environment | string, prefix: string, region?: string, ci?: boolean };

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -1,8 +1,8 @@
 import { CustomConfig, getCustomConfiguration } from './getCustomConfiguration';
 
-interface Options { cli?: boolean, prefix?: string, awsProfile?: string, environment?: string, awsRegion?: string, awsAccessKeyId?: string, awsSecretAccessKey?: string, awsSessionToken?: string }
+interface Options { ci?: boolean, prefix?: string, awsProfile?: string, environment?: string, awsRegion?: string, awsAccessKeyId?: string, awsSecretAccessKey?: string, awsSessionToken?: string }
 type PossibleCredentials = { profile?: string, accessKeyId?: string, secretAccessKey?: string, sessionToken?: string };
-type Parameters = { prefix: string, region?: string, environment?: string, cli?: boolean }
+type Parameters = { prefix: string, region?: string, environment?: string, ci?: boolean }
 export interface Command { parent: Options }
 export const getGlobalOptions = async (command: Command): Promise<{ params: Parameters, credentials: PossibleCredentials }> => {
   let customConfiguration: CustomConfig | void
@@ -16,7 +16,7 @@ export const getGlobalOptions = async (command: Command): Promise<{ params: Para
       awsAccessKeyId: accessKeyId,
       awsSecretAccessKey: secretAccessKey,
       awsSessionToken: sessionToken,
-      cli = false
+      ci = false
     }
   } = command
 
@@ -38,7 +38,7 @@ export const getGlobalOptions = async (command: Command): Promise<{ params: Para
   } else {
     return {
       credentials,
-      params: { prefix, environment, region, cli }
+      params: { prefix, environment, region, ci }
     }
   }
 }


### PR DESCRIPTION
This PR changes the option `cli` to `ci`

Originally was meant to be ci given that it was added to make ci systems run `alohomora` without too many issues in the logs (the ASCII tables used by default have colors and makes logs difficult to read)