### PR TITLE
[CustomConfiguration]: merging  with cli options if provided. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Every command accepts several options through command line or custom configurati
 
 ## Configuration
 
-You can configurate `alohomora` from several places:
+You can configure `alohomora` from several places:
 
 ### CLI options
 
@@ -205,6 +205,11 @@ When the command is invoked it will look for the `alohomora` configuration block
 ```
 
 Custom configuration can be defined in many places, for more information check [cosmiconfig](https://github.com/davidtheclark/cosmiconfig)
+
+**notes about custom configuration**
+
+- If `prefix` is provided via cli, the custom configuration will be ignored.
+- If configuration is provided via the cli, custom configuration will be merged with the provided cli configuration (except `prefix`)
 
 <!-- ROADMAP -->
 

--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,38 @@ Custom configuration can be defined in many places, for more information check [
 - If `prefix` is provided via cli, the custom configuration will be ignored.
 - If configuration is provided via the cli, custom configuration will be merged with the provided cli configuration (except `prefix`)
 
+example with overrides:
+
+```json
+"alohomora": {
+  "prefix": "my-company/my-app",
+  "region": "us-west-2",
+  "environment": "development",
+}
+```
+
+```bash
+  alo list --environment production
+```
+
+result: We will use everything from the custom configuration and use `environment` provided by the cli instead of the one on the custom configuration
+
+example ignoring custom configuration:
+
+```json
+"alohomora": {
+  "prefix": "my-company/my-app",
+  "region": "us-west-2",
+  "environment": "development",
+}
+```
+
+```bash
+  alo list prefix "my-other-company/my-other-app"
+```
+
+result: We will ignore custom configuration given that `prefix` was provided via cli.
+
 <!-- ROADMAP -->
 
 ## Roadmap

--- a/src/__tests__/getGlobalOptions.spec.ts
+++ b/src/__tests__/getGlobalOptions.spec.ts
@@ -22,6 +22,40 @@ describe('getGlobalOptions', () => {
     consoleLogMock.mockReset();
   });
 
+  it('global Options coming from customConfig and command line', async () => {
+    search.mockImplementation(() =>
+      Promise.resolve({
+        isEmpty: false,
+        filepath: '/some/package.json',
+        config: {
+          prefix: 'my-company/my-app',
+          region: 'us-west-2',
+          environment: 'development',
+        },
+      })
+    );
+
+    const response = await getGlobalOptions({
+      parent: { environment: 'production' },
+    });
+
+    expect(response).toMatchInlineSnapshot(`
+      Object {
+        "credentials": Object {
+          "accessKeyId": undefined,
+          "profile": undefined,
+          "secretAccessKey": undefined,
+          "sessionToken": undefined,
+        },
+        "params": Object {
+          "environment": "development",
+          "key": "production",
+          "prefix": "my-company/my-app",
+          "region": "us-west-2",
+        },
+      }
+    `);
+  });
   it('global Options come from customConfig', async () => {
     search.mockImplementation(() =>
       Promise.resolve({

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -5,6 +5,13 @@ type PossibleCredentials = { profile?: string, accessKeyId?: string, secretAcces
 type Parameters = { prefix: string, region?: string, environment?: string, ci?: boolean };
 export interface Command { parent: Options };
 
+type SanitizedParams = Record<string, string | number | boolean>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sanitizeParams = (params: Record<string, any>): SanitizedParams => {
+  return Object.keys(params).reduce((memo, key) => params[key] ? { ...memo, key: params[key] } : memo, {} as SanitizedParams)
+
+};
 const getOptionsFromCommand = (command: Command): [PossibleCredentials, Partial<Parameters>] => {
   const {
     parent:
@@ -36,7 +43,7 @@ export const getGlobalOptions = async (command: Command): Promise<{ params: Para
       const { prefix: customPrefix, ...rest } = customConfiguration;
       return {
         credentials,
-        params: { prefix: customPrefix, ...rest }
+        params: { prefix: customPrefix, ...rest, ...sanitizeParams(parameters) }
       }
     } else {
       console.error('prefix not provided, try again with --prefix option');


### PR DESCRIPTION
when using the library in a project I discovered that having custom configuration (mainly to keep the region and prefix there) prevents `alo` to use as well the command line options provided (if we don't provide the prefix).
 

I've added the ability to merge configurations (except prefix) and documented a bit of the behavior so it's more clear. 