### PR TITLE
shared credentials guard considering null as a value

### DIFF
--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -6,7 +6,7 @@ export const isValidTemplate = (env: string): env is Template => {
 }
 
 export const isProfileCredentials = (credentials: CredentialsOptions | null): credentials is ProfileCredentials => {
-  return credentials && 'profile' in credentials || false;
+  return credentials?.profile && true || false;
 }
 export const isAccessKeyCredentials = (credentials: CredentialsOptions | null): credentials is Credentials => {
   return credentials?.accessKeyId && credentials?.secretAccessKey && true || false;


### PR DESCRIPTION
SharedCredentials was considering `null`  as a valid `profile`, preventing other types of credentials being set.  